### PR TITLE
Add log entries to failed workitems

### DIFF
--- a/src/overrides/Helix.Sdk/CreateFailedTestsForFailedWorkItems.cs
+++ b/src/overrides/Helix.Sdk/CreateFailedTestsForFailedWorkItems.cs
@@ -32,38 +32,28 @@ namespace Microsoft.DotNet.Helix.Sdk
                     var uploadedFiles = JsonConvert.DeserializeObject<List<UploadedFile>>(failedWorkItem.GetMetadata("UploadedFiles"));
                     var details = JsonConvert.DeserializeObject<WorkItemDetails>(failedWorkItem.GetMetadata("WorkItemDetails"));
                     var fileChunk = string.Join("\n\n", uploadedFiles.Select(f => $"{f.Name}:\n  {f.Link}"));
-                    var logChunk = string.Join("\n\n", details.Logs.Select(l => $"{l.Module}:\n  {l.Uri}"));
 
-                    var text = @$"---- Files ----
-
-{fileChunk}
-
----- Logs ----
-
-{logChunk}
-";
-                    
-                    if (details.Errors.Count != 0)
+                    var text = $"---- Files ----\n\n{fileChunk}\n\n";
+                    if (details.Logs.Count != 0)
                     {
-                        text += @$"
----- Error Messages ----
-{string.Join("\n\n", details.Errors.Select(e => e.Message))}
-";
+                        text += $"---- Logs ----\n\n{string.Join("\n\n", details.Logs.Select(l => $"{l.Module}:\n  {l.Uri}"))}\n";
                     }
 
-                    if (details.Warnings.Count != 0)
+                    if (details.Errors != null && details.Errors.Count != 0)
                     {
-                        text += @$"
----- Warning Messages ----
-{string.Join("\n\n", details.Warnings.Select(e => e.Message))}
-";
+                        text += $"\n---- Error Messages ----\n{string.Join("\n\n", details.Errors.Select(e => e.Message))}\n";
+                    }
+
+                    if (details.Warnings != null && details.Warnings.Count != 0)
+                    {
+                        text += $"\n---- Warning Messages ----\n{string.Join("\n\n", details.Warnings.Select(e => e.Message))}\n";
                     }
 
                     await AttachResultFileToTestResultAsync(client, testRunId, testResultId, text);
                 }
                 catch (Exception ex)
                 {
-                    Log.LogWarningFromException(ex);
+                    Log.LogWarningFromException(ex, true);
                 }
             }
         }

--- a/src/overrides/Helix.Sdk/CreateFailedTestsForFailedWorkItems.cs
+++ b/src/overrides/Helix.Sdk/CreateFailedTestsForFailedWorkItems.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                 try
                 {
                     var uploadedFiles = JsonConvert.DeserializeObject<List<UploadedFile>>(failedWorkItem.GetMetadata("UploadedFiles"));
-                    var details = JsonConvert.DeserializeObject<WorkItemDetails>(failedWorkItem.GetMetadata("UploadedFiles"));
+                    var details = JsonConvert.DeserializeObject<WorkItemDetails>(failedWorkItem.GetMetadata("WorkItemDetails"));
                     var fileChunk = string.Join("\n\n", uploadedFiles.Select(f => $"{f.Name}:\n  {f.Link}"));
                     var logChunk = string.Join("\n\n", details.Logs.Select(l => $"{l.Module}:\n  {l.Uri}"));
 

--- a/src/overrides/Helix.Sdk/CreateFailedTestsForFailedWorkItems.cs
+++ b/src/overrides/Helix.Sdk/CreateFailedTestsForFailedWorkItems.cs
@@ -30,7 +30,17 @@ namespace Microsoft.DotNet.Helix.Sdk
                 try
                 {
                     var uploadedFiles = JsonConvert.DeserializeObject<List<UploadedFile>>(failedWorkItem.GetMetadata("UploadedFiles"));
-                    var text = string.Join(Environment.NewLine, uploadedFiles.Select(f => $"{f.Name}:{Environment.NewLine}  {f.Link}{Environment.NewLine}"));
+                    var logs = JsonConvert.DeserializeObject<List<WorkItemLog>>(failedWorkItem.GetMetadata("UploadedFiles"));
+                    var fileChunk = string.Join(Environment.NewLine, uploadedFiles.Select(f => $"{f.Name}:{Environment.NewLine}  {f.Link}{Environment.NewLine}"));
+                    var logChunk = string.Join(Environment.NewLine, logs.Select(l => $"{l.Module}:{Environment.NewLine}  {l.Uri}{Environment.NewLine}"));
+
+                    var text = @$"---- Files ----
+
+{fileChunk}
+---- Logs ----
+
+{logChunk}
+";
                     await AttachResultFileToTestResultAsync(client, testRunId, testResultId, text);
                 }
                 catch (Exception ex)

--- a/src/overrides/Helix.Sdk/GetFailedWorkItems.cs
+++ b/src/overrides/Helix.Sdk/GetFailedWorkItems.cs
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                     }
 
                     metadata["UploadedFiles"] = JsonConvert.SerializeObject(files);
-                    metadata["Logs"] = JsonConvert.SerializeObject(details.Logs);
+                    metadata["Logs"] = JsonConvert.SerializeObject(details);
                 }
                 catch (Exception ex)
                 {

--- a/src/overrides/Helix.Sdk/GetFailedWorkItems.cs
+++ b/src/overrides/Helix.Sdk/GetFailedWorkItems.cs
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                     }
 
                     metadata["UploadedFiles"] = JsonConvert.SerializeObject(files);
-                    metadata["Logs"] = JsonConvert.SerializeObject(details);
+                    metadata["WorkItemDetails"] = JsonConvert.SerializeObject(details);
                 }
                 catch (Exception ex)
                 {

--- a/src/overrides/Helix.Sdk/GetFailedWorkItems.cs
+++ b/src/overrides/Helix.Sdk/GetFailedWorkItems.cs
@@ -58,6 +58,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                 try
                 {
                     var files = await HelixApi.WorkItem.ListFilesAsync(wi, jobName, cancellationToken).ConfigureAwait(false);
+                    var details = await HelixApi.WorkItem.DetailsAsync(wi, jobName, cancellationToken).ConfigureAwait(false);
 
                     if (!string.IsNullOrEmpty(AccessToken))
                     {
@@ -68,6 +69,7 @@ namespace Microsoft.DotNet.Helix.Sdk
                     }
 
                     metadata["UploadedFiles"] = JsonConvert.SerializeObject(files);
+                    metadata["Logs"] = JsonConvert.SerializeObject(details.Logs);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
This adds the "Log" entries from the API, and any error messages